### PR TITLE
add pip install command to readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ public API.
 The example in below demonstrates how the PythonLibCore can be used with
 a library.
 
+## Installation
+To install this library, run the following command in your terminal:
+``` bash
+pip install robotframework-pythonlibcore
+```
+This command installs the latest version of `robotframework-pythonlibcore`, ensuring you have all the current features and updates.
+
 # Example
 
 ``` python


### PR DESCRIPTION
i just added a pip install in Readme file. i had to guess how to use PythonLibCore becuase this info is not listed before. 