### PR TITLE
Specify UTF-8 encoding for translation file opening

### DIFF
--- a/src/robotlibcore/utils/translations.py
+++ b/src/robotlibcore/utils/translations.py
@@ -22,7 +22,7 @@ from robot.api import logger
 
 def _translation(translation: Optional[Path] = None):
     if translation and isinstance(translation, Path) and translation.is_file():
-        with translation.open("r") as file:
+        with translation.open("r", encoding="utf-8") as file:
             try:
                 return json.load(file)
             except json.decoder.JSONDecodeError:


### PR DESCRIPTION
Fix: Open translation JSON files with explicit UTF-8 encoding

## Problem

I found this issue when trying to run the unit tests for seleniumlibrary on my Windows machine.

Translation files containing non-ASCII characters (e.g. Finnish `ä`, `ö`) are read incorrectly on Windows. The `_translation()` function in `utils/translations.py` opens the file without specifying an encoding, so Python falls back to the system locale encoding (`cp1252` on Windows). This silently corrupts keyword names and documentation containing multi-byte UTF-8 characters.

For example, a translated keyword name `hallinnoi_hälytys` is stored as `hallinnoi_hÃ¤lytys` in `keywords_spec`, making it impossible to look up by its correct name.

This does not affect CI pipelines running on Linux, where the default encoding is already UTF-8, which explains why the bug only reproduces locally on Windows.

## Fix

Pass `encoding="utf-8"` explicitly when opening the translation file in `utils/translations.py`:

```python
# Before
with translation.open("r") as file:

# After
with translation.open("r", encoding="utf-8") as file: