### PR TITLE
docs: fix 3 typo(s) in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,10 +116,10 @@ class Library2(object):
 
 It is possible to create plugin API to a library by using PythonLibCore.
 This allows extending library with external Python classes. Plugins can
-be imported during library import time, example by defining argumet in
+be imported during library import time, example by defining argument in
 library [\_\_init\_\_]{.title-ref} which allows defining the plugins. It
-is possible to define multiple plugins, by seperating plugins with with
-comma. Also it is possible to provide arguments to plugin by seperating
+is possible to define multiple plugins, by separating plugins with with
+comma. Also it is possible to provide arguments to plugin by separating
 arguments with semicolon.
 
 ``` python


### PR DESCRIPTION
## Summary

Fixed 3 typo(s) found in documentation files while reading the docs.

## Changes

- `README.md` L119: `argumet` → `argument`
- `README.md` L121: `seperating` → `separating`
- `README.md` L122: `seperating` → `separating`

## Type of change

- [x] Documentation fix (typo/spelling only)

## Checklist

- [x] I have read the contributing guidelines
- [x] My changes follow the existing documentation style
- [x] No code changes — documentation only

---

*Found via automated spell-check. Please review each fix carefully. Happy to adjust if any correction doesn't fit the intended meaning.*
